### PR TITLE
change rust scaffold to lib and add config for it

### DIFF
--- a/src/cli/scaffold/rust.rs
+++ b/src/cli/scaffold/rust.rs
@@ -31,17 +31,17 @@ impl Scaffold for RustScaffold {
     fn gen<P: AsRef<Path>>(&self, base_path: P) -> DefaultResult<()> {
         fs::create_dir_all(&base_path)?;
 
-        // use cargo to initialise a Rust app without any version control
+        // use cargo to initialise a library Rust crate without any version control
         util::run_cmd(
             base_path.as_ref().to_path_buf(),
             "cargo".into(),
-            vec!["init".to_owned(), "--vcs".to_owned(), "none".to_owned()],
+            vec!["init".to_owned(), "--lib".to_owned(), "--vcs".to_owned(), "none".to_owned()],
         )?;
 
         // add hdk-rust dependency by default
         let cargo_file_path = base_path.as_ref().join(package::CARGO_FILE_NAME);
 
-        let mut f = OpenOptions::new()
+        let mut cargo_file = OpenOptions::new()
             .append(true)
             .open(cargo_file_path)?;
 
@@ -51,14 +51,19 @@ impl Scaffold for RustScaffold {
         // the above TODO hasn't been addressed, this should also be updated
         let hdk_dep: &str = "hdk = { git = \"https://github.com/holochain/hdk-rust\", branch = \"master\" }";
 
-        f.write_all(hdk_dep.as_bytes())?;
+        cargo_file.write_all(hdk_dep.as_bytes())?;
+
+        // add WASM friendly lib configuration properties
+        let lib_config: &str = "\n\n[lib]\npath = \"src/lib.rs\"\ncrate-type = [\"cdylib\"]";
+
+        cargo_file.write_all(lib_config.as_bytes())?;
 
         // create and fill in a build file appropriate for Rust
         let build_file_path = base_path.as_ref().join(package::BUILD_CONFIG_FILE_NAME);
 
-        let file = File::create(build_file_path)?;
+        let build_file = File::create(build_file_path)?;
 
-        serde_json::to_writer_pretty(file, &self.build_template)?;
+        serde_json::to_writer_pretty(build_file, &self.build_template)?;
 
         Ok(())
     }

--- a/src/cli/scaffold/rust.rs
+++ b/src/cli/scaffold/rust.rs
@@ -3,8 +3,8 @@ use error::DefaultResult;
 use serde_json;
 use std::{
     fs::{self, File, OpenOptions},
+    io::Write,
     path::Path,
-    io::{Write}
 };
 use util;
 
@@ -35,21 +35,25 @@ impl Scaffold for RustScaffold {
         util::run_cmd(
             base_path.as_ref().to_path_buf(),
             "cargo".into(),
-            vec!["init".to_owned(), "--lib".to_owned(), "--vcs".to_owned(), "none".to_owned()],
+            vec![
+                "init".to_owned(),
+                "--lib".to_owned(),
+                "--vcs".to_owned(),
+                "none".to_owned(),
+            ],
         )?;
 
         // add hdk-rust dependency by default
         let cargo_file_path = base_path.as_ref().join(package::CARGO_FILE_NAME);
 
-        let mut cargo_file = OpenOptions::new()
-            .append(true)
-            .open(cargo_file_path)?;
+        let mut cargo_file = OpenOptions::new().append(true).open(cargo_file_path)?;
 
         // @TODO switch to crates.io ref when hdk-rust gets published
         // @see https://github.com/holochain/holochain-cmd/issues/19
         // Also, caution, if hdk-rust switches to git flow style and "develop" branch, and
         // the above TODO hasn't been addressed, this should also be updated
-        let hdk_dep: &str = "hdk = { git = \"https://github.com/holochain/hdk-rust\", branch = \"master\" }";
+        let hdk_dep: &str =
+            "hdk = { git = \"https://github.com/holochain/hdk-rust\", branch = \"master\" }";
 
         cargo_file.write_all(hdk_dep.as_bytes())?;
 

--- a/src/cli/scaffold/rust.rs
+++ b/src/cli/scaffold/rust.rs
@@ -58,7 +58,7 @@ impl Scaffold for RustScaffold {
         cargo_file.write_all(hdk_dep.as_bytes())?;
 
         // add WASM friendly lib configuration properties
-        let lib_config: &str = "\n\n[lib]\npath = \"src/lib.rs\"\ncrate-type = [\"cdylib\"]";
+        let lib_config: &str = "\n\n[lib]\npath = \"src/lib.rs\"\ncrate-type = [\"cdylib\"]\n";
 
         cargo_file.write_all(lib_config.as_bytes())?;
 


### PR DESCRIPTION
closes #23 

what Cargo.toml looks like now: it adds the last three lines of the file
![screen shot 2018-08-30 at 3 49 34 pm](https://user-images.githubusercontent.com/1409121/44876043-d59c4080-ac6d-11e8-92ab-68e20368d312.png)

For background on `cdylib` I found this:
"A dynamic system library will be produced. This is used when compiling Rust code as a dynamic library to be loaded from another language. This output type will create *.so files on Linux, *.dylib files on macOS, and *.dll files on Windows."
https://doc.rust-lang.org/reference/linkage.html