### PR TITLE
hcdev test improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Some of these should be configurable options soon.
 
 You have the flexibility to write tests in quite a variety of ways, open to you to explore.
 
-**Note about default configuration with TAPE testing**: If you use the default configuration with Tape for testing, to get an improved CLI visual output (with colors!), we recommend adjusting the command you use to run tests as follows:
+**Note about default configuration with TAPE testing**: If you use the default configuration with Tape for testing, to get an improved CLI visual output (with colors! and accurate script exit codes), we recommend adjusting the command you use to run tests as follows:
 ```
 hcdev test | test/node_modules/faucet/bin/cmd.js
 ```

--- a/README.md
+++ b/README.md
@@ -158,8 +158,25 @@ Once you have a project folder initiated, you can run `hcdev test` to execute yo
   2. Installing build and testing dependencies, if they're not installed (`npm install`)
   3. Building a single JS file used for testing, placed at `test/dist/bundle.js` (`npm run build`)
   4. Executing (with [holoconsole](https://github.com/holochain/holosqape)) the test file found at `test/dist/bundle.js`
-  
-Some of these should be configurable options soon.
+
+`hcdev test` also has some configurable options.
+
+If you want to run it without running the `npm` commands, run it with
+```shell
+hcdev test --npm=false
+```
+
+If your tests are in a different folder than `test`, run it with
+```shell
+hcdev test --dir tests
+```
+ where `tests` is the name of the folder.
+
+If the file you wish to actually execute is somewhere besides `test/dist/bundle.js` then run it with
+```shell
+hcdev test --testfile test/test.js
+```
+where `test/test.js` is the path of the file.
 
 You have the flexibility to write tests in quite a variety of ways, open to you to explore.
 

--- a/README.md
+++ b/README.md
@@ -149,32 +149,32 @@ Once that's done, you should be able to run commands like `cargo build --target=
 Once all of this is set up, you can build and run your `.hcpkg` file with Holochain!
 
 ### Writing and Running Tests
-By default, when you use `hcdev init` to create a new project folder, it creates a sub-directory called `test`. The files in that folder are equipped for testing your project. 
+By default, when you use `hc init` to create a new project folder, it creates a sub-directory called `test`. The files in that folder are equipped for testing your project. 
 
 Checkout the README of our default testing configuration to understand how to write your tests in Javascript: [https://github.com/holochain/js-tests-scaffold](https://github.com/holochain/js-tests-scaffold).
 
-Once you have a project folder initiated, you can run `hcdev test` to execute your tests. This combines the following steps:
+Once you have a project folder initiated, you can run `hc test` to execute your tests. This combines the following steps:
   1. Packaging your files into a DNA file, located at `dist/bundle.json`. This step will fail if your packaging step fails.
   2. Installing build and testing dependencies, if they're not installed (`npm install`)
   3. Building a single JS file used for testing, placed at `test/dist/bundle.js` (`npm run build`)
   4. Executing (with [holoconsole](https://github.com/holochain/holosqape)) the test file found at `test/dist/bundle.js`
 
-`hcdev test` also has some configurable options.
+`hc test` also has some configurable options.
 
 If you want to run it without running the `npm` commands, run it with
 ```shell
-hcdev test --skip-npm
+hc test --skip-npm
 ```
 
 If your tests are in a different folder than `test`, run it with
 ```shell
-hcdev test --dir tests
+hc test --dir tests
 ```
  where `tests` is the name of the folder.
 
 If the file you wish to actually execute is somewhere besides `test/dist/bundle.js` then run it with
 ```shell
-hcdev test --testfile test/test.js
+hc test --testfile test/test.js
 ```
 where `test/test.js` is the path of the file.
 
@@ -182,7 +182,7 @@ You have the flexibility to write tests in quite a variety of ways, open to you 
 
 **Note about default configuration with TAPE testing**: If you use the default configuration with Tape for testing, to get an improved CLI visual output (with colors! and accurate script exit codes), we recommend adjusting the command you use to run tests as follows:
 ```
-hcdev test | test/node_modules/faucet/bin/cmd.js
+hc test | test/node_modules/faucet/bin/cmd.js
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Once you have a project folder initiated, you can run `hcdev test` to execute yo
 
 If you want to run it without running the `npm` commands, run it with
 ```shell
-hcdev test --npm=false
+hcdev test --skip-npm
 ```
 
 If your tests are in a different folder than `test`, run it with

--- a/README.md
+++ b/README.md
@@ -148,6 +148,27 @@ Once that's done, you should be able to run commands like `cargo build --target=
 
 Once all of this is set up, you can build and run your `.hcpkg` file with Holochain!
 
+### Writing and Running Tests
+By default, when you use `hcdev init` to create a new project folder, it creates a sub-directory called `test`. The files in that folder are equipped for testing your project. 
+
+Checkout the README of our default testing configuration to understand how to write your tests in Javascript: [https://github.com/holochain/js-tests-scaffold](https://github.com/holochain/js-tests-scaffold).
+
+Once you have a project folder initiated, you can run `hcdev test` to execute your tests. This combines the following steps:
+  1. Packaging your files into a DNA file, located at `dist/bundle.json`. This step will fail if your packaging step fails.
+  2. Installing build and testing dependencies, if they're not installed (`npm install`)
+  3. Building a single JS file used for testing, placed at `test/dist/bundle.js` (`npm run build`)
+  4. Executing (with [holoconsole](https://github.com/holochain/holosqape)) the test file found at `test/dist/bundle.js`
+  
+Some of these should be configurable options soon.
+
+You have the flexibility to write tests in quite a variety of ways, open to you to explore.
+
+**Note about default configuration with TAPE testing**: If you use the default configuration with Tape for testing, to get an improved CLI visual output (with colors!), we recommend adjusting the command you use to run tests as follows:
+```
+hcdev test | test/node_modules/faucet/bin/cmd.js
+```
+
+
 ## Contribute
 Holochain is an open source project.  We welcome all sorts of participation and are actively working on increasing surface area to accept it.  Please see our [contributing guidelines](https://github.com/holochain/org/blob/master/CONTRIBUTING.md) for our general practices and protocols on participating in the community.
 

--- a/src/cli/test.rs
+++ b/src/cli/test.rs
@@ -10,7 +10,7 @@ use std::{
 pub const TEST_DIR_NAME: &str = "test";
 pub const DIST_DIR_NAME: &str = "dist";
 
-pub fn test(path: &PathBuf, tests_folder: &str) -> DefaultResult<()> {
+pub fn test(path: &PathBuf, tests_folder: &str, testfile: &str, npm: bool) -> DefaultResult<()> {
 
     // create dist folder
     let dist_path = path.join(&DIST_DIR_NAME);
@@ -30,41 +30,44 @@ pub fn test(path: &PathBuf, tests_folder: &str) -> DefaultResult<()> {
 
     // build tests
     let tests_path = path.join(&tests_folder);
+    ensure!(
+        tests_path.exists(),
+        "Directory {} does not exist",
+        tests_folder
+    );
 
-    // npm install, if no node_modules yet
-    let node_modules_path = tests_path.join("node_modules");
-    if !node_modules_path.exists() {
-        // execute the built test file using holoconsole
-        println!("{}", "Installing node_modules".green().bold());
+    if npm {
+        // npm install, if no node_modules yet
+        let node_modules_path = tests_path.join("node_modules");
+        if !node_modules_path.exists() {
+            // execute the built test file using holoconsole
+            println!("{}", "Installing node_modules".green().bold());
+            util::run_cmd(tests_path.clone(), "npm".to_string(), vec![
+                "install".to_string(),
+                "--silent".to_string(),
+            ])?;
+        }
+
+        // npm run build
+        println!(
+            "{} an executable test file: {}",
+            "Building".green().bold(),
+            testfile,
+        );
         util::run_cmd(tests_path.clone(), "npm".to_string(), vec![
-            "install".to_string(),
-            "--silent".to_string(),
+            "run".to_string(),
+            "build".to_string(),
         ])?;
     }
-
-    // npm run build
-    // this "magic string" comes from the webpack config
-    // in the js-tests-scaffold: https://github.com/holochain/js-tests-scaffold/blob/master/webpack.config.js#L5-L8
-    // they need to stay in sync
-    let js_test_path = format!("{}{}", &tests_folder, "/dist/bundle.js");
-    println!(
-        "{} an executable test file: {}",
-        "Building".green().bold(),
-        js_test_path
-    );
-    util::run_cmd(tests_path.clone(), "npm".to_string(), vec![
-        "run".to_string(),
-        "build".to_string(),
-    ])?;
 
     // execute the built test file using holoconsole
     println!(
         "{} tests in {}",
         "Running".green().bold(),
-        js_test_path
+        testfile,
     );
     util::run_cmd(path.to_path_buf(), "holoconsole".to_string(), vec![
-        js_test_path,
+        testfile.to_string(),
     ])?;
 
     Ok(())
@@ -88,9 +91,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_command_test() {
-        // because we pass the commit as well
-        // this test is deterministic
+    fn test_command_basic_test() {
         let temp_space = gen_dir();
         let temp_dir_path = temp_space.path();
         let temp_dir_path_buf = temp_space.path().to_path_buf();
@@ -102,13 +103,59 @@ pub mod tests {
                 .assert()
                 .success();
 
-        test(&temp_dir_path_buf, &TEST_DIR_NAME);
+        let result = test(&temp_dir_path_buf, &TEST_DIR_NAME, "test/dist/bundle.js", true);
 
+        assert!(result.is_ok());
         // check success of packaging step
         assert!(temp_dir_path_buf.join(&DIST_DIR_NAME).join(package::DEFAULT_BUNDLE_FILE_NAME).exists());
         // check success of npm install step
         assert!(temp_dir_path_buf.join(&TEST_DIR_NAME).join("node_modules").exists());
         // check success of js webpack build step
         assert!(temp_dir_path_buf.join(&TEST_DIR_NAME).join("dist/bundle.js").exists());
+    }
+
+    #[test]
+    fn test_command_no_npm() {
+        let temp_space = gen_dir();
+        let temp_dir_path = temp_space.path();
+        let temp_dir_path_buf = temp_space.path().to_path_buf();
+
+        // do init first, so theres a project
+        Command::main_binary()
+                .unwrap()
+                .args(&["init", temp_dir_path.to_str().unwrap()])
+                .assert()
+                .success();
+
+        let result = test(&temp_dir_path_buf, &TEST_DIR_NAME, "test/dist/index.js", false);
+
+        // is err because "holoconsole test/dist/index.js" will have failed
+        // but the important thing is that the npm calls weren't made
+        assert!(result.is_err());
+        // check success of packaging step
+        assert!(temp_dir_path_buf.join(&DIST_DIR_NAME).join(package::DEFAULT_BUNDLE_FILE_NAME).exists());
+        // npm shouldn't have installed
+        assert!(!temp_dir_path_buf.join(&TEST_DIR_NAME).join("node_modules").exists());
+        // built file shouldn't exist
+        assert!(!temp_dir_path_buf.join(&TEST_DIR_NAME).join("dist/bundle.js").exists());
+    }
+
+    #[test]
+    fn test_command_no_test_folder() {
+        let temp_space = gen_dir();
+        let temp_dir_path = temp_space.path();
+        let temp_dir_path_buf = temp_space.path().to_path_buf();
+
+        // do init first, so theres a project
+        Command::main_binary()
+                .unwrap()
+                .args(&["init", temp_dir_path.to_str().unwrap()])
+                .assert()
+                .success();
+
+        let result = test(&temp_dir_path_buf, "west", "test/dist/bundle.js", true);
+
+        // should err because "west" directory doesn't exist
+        assert!(result.is_err());
     }
 }

--- a/src/cli/test.rs
+++ b/src/cli/test.rs
@@ -10,7 +10,7 @@ use std::{
 pub const TEST_DIR_NAME: &str = "test";
 pub const DIST_DIR_NAME: &str = "dist";
 
-pub fn test(path: &PathBuf, tests_folder: &str, testfile: &str, npm: bool) -> DefaultResult<()> {
+pub fn test(path: &PathBuf, tests_folder: &str, testfile: &str, skip_npm: bool) -> DefaultResult<()> {
 
     // create dist folder
     let dist_path = path.join(&DIST_DIR_NAME);
@@ -36,7 +36,7 @@ pub fn test(path: &PathBuf, tests_folder: &str, testfile: &str, npm: bool) -> De
         tests_folder
     );
 
-    if npm {
+    if !skip_npm {
         // npm install, if no node_modules yet
         let node_modules_path = tests_path.join("node_modules");
         if !node_modules_path.exists() {
@@ -103,7 +103,7 @@ pub mod tests {
                 .assert()
                 .success();
 
-        let result = test(&temp_dir_path_buf, &TEST_DIR_NAME, "test/dist/bundle.js", true);
+        let result = test(&temp_dir_path_buf, &TEST_DIR_NAME, "test/dist/bundle.js", false);
 
         assert!(result.is_ok());
         // check success of packaging step
@@ -127,7 +127,7 @@ pub mod tests {
                 .assert()
                 .success();
 
-        let result = test(&temp_dir_path_buf, &TEST_DIR_NAME, "test/dist/index.js", false);
+        let result = test(&temp_dir_path_buf, &TEST_DIR_NAME, "test/dist/index.js", true);
 
         // is err because "holoconsole test/dist/index.js" will have failed
         // but the important thing is that the npm calls weren't made
@@ -153,7 +153,7 @@ pub mod tests {
                 .assert()
                 .success();
 
-        let result = test(&temp_dir_path_buf, "west", "test/dist/bundle.js", true);
+        let result = test(&temp_dir_path_buf, "west", "test/dist/bundle.js", false);
 
         // should err because "west" directory doesn't exist
         assert!(result.is_err());

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,11 +118,11 @@ enum Cli {
         )]
         testfile: Option<String>,
         #[structopt(
-            long = "npm",
-            short = "n",
-            help = "Whether to run npm install and npm run build, defaults to true",
+            long = "skip-npm",
+            short = "s",
+            help = "Skip npm install and npm run build, defaults to false",
         )]
-        npm: Option<bool>,
+        skip_npm: Option<bool>,
     },
 }
 
@@ -152,14 +152,14 @@ fn run() -> HolochainResult<()> {
         Cli::Generate { zome, language } => {
             cli::generate(&zome, &language).or_else(|err| Err(HolochainError::Default(err)))?
         }
-        Cli::Test { dir, testfile, npm }=> {
+        Cli::Test { dir, testfile, skip_npm }=> {
             let tests_folder = dir.unwrap_or(cli::TEST_DIR_NAME.to_string());
             // this "magic string" comes from the webpack config
             // in the js-tests-scaffold: https://github.com/holochain/js-tests-scaffold/blob/master/webpack.config.js#L5-L8
             // they need to stay in sync
             let test_file = testfile.unwrap_or("test/dist/bundle.js".to_string());
-            let run_npm = npm.unwrap_or(true);
-            cli::test(&PathBuf::new().join("."), &tests_folder, &test_file, run_npm).or_else(|err| Err(HolochainError::Default(err)))?
+            let bool_skip_npm = skip_npm.unwrap_or(false);
+            cli::test(&PathBuf::new().join("."), &tests_folder, &test_file, bool_skip_npm).or_else(|err| Err(HolochainError::Default(err)))?
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,26 @@ enum Cli {
         alias = "t",
         about = "Runs tests written in the test folder"
     )]
-    Test,
+    Test {
+        #[structopt(
+            long = "dir",
+            short = "d",
+            help = "The folder containing the test files, defaults to 'test'",
+        )]
+        dir: Option<String>,
+        #[structopt(
+            long = "testfile",
+            short = "t",
+            help = "The path of the file to test, defaults to 'test/dist/bundle.js'",
+        )]
+        testfile: Option<String>,
+        #[structopt(
+            long = "npm",
+            short = "n",
+            help = "Whether to run npm install and npm run build, defaults to true",
+        )]
+        npm: Option<bool>,
+    },
 }
 
 fn main() {
@@ -133,9 +152,14 @@ fn run() -> HolochainResult<()> {
         Cli::Generate { zome, language } => {
             cli::generate(&zome, &language).or_else(|err| Err(HolochainError::Default(err)))?
         }
-        Cli::Test => {
-            // just call with defaults, no cli config
-            cli::test(&PathBuf::new().join("."), &cli::TEST_DIR_NAME).or_else(|err| Err(HolochainError::Default(err)))?
+        Cli::Test { dir, testfile, npm }=> {
+            let tests_folder = dir.unwrap_or(cli::TEST_DIR_NAME.to_string());
+            // this "magic string" comes from the webpack config
+            // in the js-tests-scaffold: https://github.com/holochain/js-tests-scaffold/blob/master/webpack.config.js#L5-L8
+            // they need to stay in sync
+            let test_file = testfile.unwrap_or("test/dist/bundle.js".to_string());
+            let run_npm = npm.unwrap_or(true);
+            cli::test(&PathBuf::new().join("."), &tests_folder, &test_file, run_npm).or_else(|err| Err(HolochainError::Default(err)))?
         }
     }
 


### PR DESCRIPTION
Add hcdev test section to the readme

Makes `hcdev test` CLI command configurable, but with good defaults

closes #53 
closes #51 

adds hcdev test tests