### PR TITLE
allow sub dependency of hdk-assemblyscript to replace this

### DIFF
--- a/src/cli/scaffold/assemblyscript.rs
+++ b/src/cli/scaffold/assemblyscript.rs
@@ -52,17 +52,6 @@ impl Scaffold for AssemblyScriptScaffold {
             ],
         )?;
 
-        // add assemblyscript as a dev dependency
-        util::run_cmd(
-            base_path.as_ref().to_path_buf(),
-            "npm".into(),
-            vec![
-                "install".to_owned(),
-                "--save-dev".to_owned(),
-                "AssemblyScript/assemblyscript".to_owned()
-            ],
-        )?;
-
         // create a index.ts file
         let typescript_file_path = base_path.as_ref().join(TYPESCRIPT_FILE_NAME);
 


### PR DESCRIPTION
tests are failing on master branch because of an upstream change
https://travis-ci.com/holochain/holochain-cmd/builds/87628086

hc generate zomes/users assemblyscript now breaks because of an update to hdk-assemblyscript. We now have our own Assemblyscript fork

https://github.com/holochain/assemblyscript