### PR TITLE
59 - use submodule, not git clone for test files scaffold

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "js-tests-scaffold"]
+	path = src/cli/js-tests-scaffold
+	url = https://github.com/holochain/js-tests-scaffold.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "src/cli/js-tests-scaffold"]
+	path = src/cli/js-tests-scaffold
+	url = https://github.com/holochain/js-tests-scaffold.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "js-tests-scaffold"]
-	path = src/cli/js-tests-scaffold
-	url = https://github.com/holochain/js-tests-scaffold.git
-	branch = master

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ To install the Holochain command line, run the following commands in a terminal
 ```shell
 $ git clone https://github.com/holochain/holochain-cmd.git
 $ cd holochain-cmd
-$ git submodules init
-$ git submodules update
+$ git submodule init
+$ git submodule update
 $ cargo install -f --path .
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ To install the Holochain command line, run the following commands in a terminal
 ```shell
 $ git clone https://github.com/holochain/holochain-cmd.git
 $ cd holochain-cmd
+$ git submodules init
+$ git submodules update
 $ cargo install -f --path .
 ```
 

--- a/docker/update
+++ b/docker/update
@@ -4,12 +4,16 @@
 #cargo +nightly-2018-07-17-x86_64-unknown-linux-gnu install fmt
 #rustup default nightly
 
+cd /holochain/holochain-cmd
+git submodule init
+git submodule update
+
 cd /holochain/holosqape
 git pull
 git submodule init
 git submodule update
 
-echo "COMPILING HOLORUST"
+echo "COMPILING HOLOCHAIN RUST"
 cd /holochain/holosqape/holochain-rust
 cargo update
 cargo +$TOOLS_NIGHTLY build --release

--- a/src/cli/new.rs
+++ b/src/cli/new.rs
@@ -8,57 +8,29 @@ use cli::test::{
     TEST_DIR_NAME,
     DIST_DIR_NAME,
 };
-use util;
 use error::DefaultResult;
 use serde_json;
 use std::{
-    fs::{self, File},
+    fs::{self, File, OpenOptions},
     path::{PathBuf},
     io::Write,
 };
 
-struct TestRepo {
-    name: String,
-    url: String,
-    commit: Option<String>
+fn create_test_file(test_folder_path: &PathBuf, test_file_name: &str, test_file_contents: &str) -> DefaultResult<()> {
+    let dest_filepath = test_folder_path.join(test_file_name);
+    let mut file = OpenOptions::new().write(true).create(true).open(dest_filepath)?;
+    file.write_all(test_file_contents.as_bytes())?;
+    Ok(())
 }
 
-fn setup_test_folder(path: &PathBuf, test_folder: &str, test_repo: TestRepo) -> DefaultResult<()> {
-
-    // check if there was a specific commit to checkout, or just latest
-    match test_repo.commit {
-        Some(sha) => {
-            // clone the repo with history
-            util::run_cmd(path.clone(), "git".to_string(), vec![
-                "clone".to_string(),
-                "--quiet".to_string(),
-                test_repo.url.to_string(),
-                test_folder.to_string(),
-            ])?;
-            // checkout the desired commit
-            let temp_dir = path.join(test_repo.name.to_string());
-            util::run_cmd(temp_dir, "git".to_string(), vec![
-                "checkout".to_string(),
-                sha.to_string(),
-                "--quiet".to_string(),
-            ])?;
-        },
-        None => {
-            // clone the repo without history
-            util::run_cmd(path.clone(), "git".to_string(), vec![
-                "clone".to_string(),
-                "--quiet".to_string(),
-                "--depth".to_string(),
-                "1".to_string(),
-                test_repo.url.to_string(),
-                test_folder.to_string(),
-            ])?;
-        },
-    }
-
-    // remove the .git folder
-    fs::remove_dir_all(path.join(test_folder).join(".git"))?;
-
+fn setup_test_folder(path: &PathBuf, test_folder: &str) -> DefaultResult<()> {
+    let tests_path = path.join(test_folder);
+    fs::create_dir_all(tests_path.clone())?;
+    create_test_file(&tests_path, "index.js", include_str!("js-tests-scaffold/index.js"))?;
+    create_test_file(&tests_path, "package-lock.json", include_str!("js-tests-scaffold/package-lock.json"))?;
+    create_test_file(&tests_path, "package.json", include_str!("js-tests-scaffold/package.json"))?;
+    create_test_file(&tests_path, "README.md", include_str!("js-tests-scaffold/README.md"))?;
+    create_test_file(&tests_path, "webpack.config.js", include_str!("js-tests-scaffold/webpack.config.js"))?;
     Ok(())
 }
 
@@ -84,16 +56,7 @@ pub fn new(path: &PathBuf, _from: &Option<String>) -> DefaultResult<()> {
     let mut hcignore_file = File::create(path.join(&IGNORE_FILE_NAME))?;
     hcignore_file.write_all(ignores.as_bytes())?;
 
-    // currently choosing to just clone the latest
-    // rather than passing a fixed commit, so that
-    // the repo can be updated, and developers
-    // don't need to update their command line tools
-    let test_repo = TestRepo {
-        name: "js-tests-scaffold".to_string(),
-        url: "https://github.com/holochain/js-tests-scaffold.git".to_string(),
-        commit: None
-    };
-    setup_test_folder(&path, &TEST_DIR_NAME, test_repo)?;
+    setup_test_folder(&path, &TEST_DIR_NAME)?;
 
     println!(
         "{} new Holochain project at: {:?}",
@@ -125,15 +88,11 @@ pub mod tests {
         // this test is deterministic
         let dir = gen_dir();
         let dir_path_buf = &dir.path().to_path_buf();
-        let test_repo = TestRepo {
-            name: "js-tests-scaffold".to_string(),
-            url: "https://github.com/holochain/js-tests-scaffold.git".to_string(),
-            commit: Some("26825da5b19a0e4c14273174f9776f929b05c967".to_string())
-        };
-        setup_test_folder(dir_path_buf, &TEST_DIR_NAME, test_repo);
+        setup_test_folder(dir_path_buf, &TEST_DIR_NAME);
 
         assert!(dir_path_buf.join(&TEST_DIR_NAME).join("index.js").exists());
         assert!(dir_path_buf.join(&TEST_DIR_NAME).join("package.json").exists());
+        assert!(dir_path_buf.join(&TEST_DIR_NAME).join("package-lock.json").exists());
         assert!(dir_path_buf.join(&TEST_DIR_NAME).join("webpack.config.js").exists());
         assert!(dir_path_buf.join(&TEST_DIR_NAME).join("README.md").exists());
     }


### PR DESCRIPTION
Did this because after discussing with @maackle and @JettTech we realized that we really didn't like dependent on a network connection for `hc init` to fully work.

Also, now we don't have to worry about things changing/breaking, because of updates in that other js-tests-scaffold repo. We can 'pull' updates, by updating the git submodle

closes #59 