### PR TITLE
disable assemblyscript and drop zome.json file

### DIFF
--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -3,14 +3,10 @@ use cli::{
     scaffold::{self, Scaffold},
 };
 use error::DefaultResult;
-use serde_json;
 use std::{
-    fs::{self, File},
+    fs,
     path::PathBuf,
 };
-use util;
-
-pub const ZOME_CONFIG_FILE_NAME: &str = "zome.json";
 
 pub fn generate(zome_name: &PathBuf, language: &str) -> DefaultResult<()> {
     if !zome_name.exists() {
@@ -21,17 +17,6 @@ pub fn generate(zome_name: &PathBuf, language: &str) -> DefaultResult<()> {
         zome_name.is_dir(),
         "argument \"zome_name\" doesn't point to a directory"
     );
-
-    let file_name = util::file_name_string(&zome_name)?;
-
-    let zome_config_json = json!{
-        {
-            "description": format!("The {} App", file_name)
-        }
-    };
-
-    let file = File::create(zome_name.join(ZOME_CONFIG_FILE_NAME))?;
-    serde_json::to_writer_pretty(file, &zome_config_json)?;
 
     let code_dir = zome_name.join(CODE_DIR_NAME);
     fs::create_dir_all(&code_dir)?;
@@ -44,7 +29,7 @@ pub fn generate(zome_name: &PathBuf, language: &str) -> DefaultResult<()> {
     // match against all supported languages
     match language {
         "rust" => scaffold(&scaffold::rust::RustScaffold::new(zome_name_string), code_dir)?,
-        "assemblyscript" => scaffold(&scaffold::assemblyscript::AssemblyScriptScaffold::new(), code_dir)?,
+        // "assemblyscript" => scaffold(&scaffold::assemblyscript::AssemblyScriptScaffold::new(), code_dir)?,
         // TODO: supply zome name for AssemblyScriptScaffold as well
         _ => bail!("unsupported language: {}", language),
     }


### PR DESCRIPTION
zome.json isn't necessary, as seen in app-spec-rust zomes

also, just pretend assemblyscript generator doesn't exist, since you'll just get blocked when you discover it's not ready / complete yet