### PR TITLE
updates to work against holochain-rust:c90f19aa816

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 services:
   - docker
 
-dist: trusty
+dist: xenial
 
 jobs:
   include:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 
 [dependencies]
 holochain_core = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
+holochain_core_types = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
 holochain_dna = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
-holochain_agent = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
 holochain_cas_implementations = { git = "https://github.com/holochain/holochain-rust", branch = "develop" }
 structopt = "0.2"
 failure = "^0.1"

--- a/docker/Dockerfile.holochain-cmd
+++ b/docker/Dockerfile.holochain-cmd
@@ -1,11 +1,18 @@
 FROM holochain/holochain-rust:develop
 
+USER root
+
 RUN apt-get update && apt-get install --yes \
   qtdeclarative5-dev \
   libqt5websockets5-dev \
-  libreadline6-dev
+  libreadline6-dev \
+  software-properties-common
 
-USER root
+# Install latest version of QT needed for hcshell
+RUN add-apt-repository ppa:beineri/opt-qt-5.11.1-xenial
+RUN apt-get update
+RUN apt-get --yes install qt511-meta-full
+RUN printf "/opt/qt511/bin\n/opt/qt511/lib" > /etc/xdg/qtchooser/default.conf
 
 RUN rustup toolchain install nightly-x86_64-unknown-linux-gnu
 RUN rustup toolchain install nightly-2018-07-17-x86_64-unknown-linux-gnu

--- a/src/cli/test_context.rs
+++ b/src/cli/test_context.rs
@@ -5,7 +5,7 @@ use holochain_core::{
     logger::Logger,
     persister::SimplePersister,
 };
-use holochain_agent::Agent;
+use holochain_core_types::entry::agent::Agent;
 use holochain_cas_implementations::{cas::file::FilesystemStorage, eav::file::EavFileStorage};
 use std::sync::{Arc, Mutex};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-extern crate holochain_agent;
+extern crate holochain_core_types;
 extern crate holochain_cas_implementations;
 extern crate holochain_core;
 extern crate holochain_dna;


### PR DESCRIPTION
which moved agent crate into core_types.

This needs to get merged before `app-spec-rust`  CI fixes can get merged because they depend on a clean run of the hc-cmd build which is not failing because of the agent crate move but which this PR fixes.

Also added fixes in here to dockerfile re Qt version installation (same as for app-spec)