### PR TITLE
fixes to docker and scripts for correct node version from upstream

### DIFF
--- a/docker/Dockerfile.holochain-cmd
+++ b/docker/Dockerfile.holochain-cmd
@@ -1,9 +1,6 @@
 FROM holochain/holochain-rust:develop
 
-USER root
-
 RUN apt-get update && apt-get install --yes \
-  nodejs-legacy \
   libreadline6-dev \
   software-properties-common
 

--- a/docker/build
+++ b/docker/build
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build -f docker/Dockerfile.holochain-cmd -t holochain/holochain-cmd:latest "$@" .
+docker build -f docker/Dockerfile.holochain-cmd -t holochain/holochain-cmd:develop "$@" .

--- a/docker/entry
+++ b/docker/entry
@@ -7,7 +7,7 @@ if [ -n "$HOST_UID" ]; then
     groupmod -g "$HOST_UID" holochain
     usermod -g "$HOST_UID" holochain
     chown -R -h "$HOST_UID":"$HOST_UID" /home/holochain
-	chown -R -h "$HOST_UID":"$HOST_UID" /home/holochain/*
+    chown -R -h "$HOST_UID":"$HOST_UID" /home/holochain/*
   fi
 fi
 

--- a/docker/update
+++ b/docker/update
@@ -5,8 +5,11 @@
 #rustup default nightly
 
 cd /holochain/holochain-cmd
+git reset --hard
+git pull
 git submodule init
 git submodule update
+cargo update
 
 cd /holochain/holosqape
 git reset --hard


### PR DESCRIPTION
holochain/holochain-rust docker image (from same named branch) installs node 11, this branch to match.  Also fixes docker/update